### PR TITLE
tests: add snapshot tests via insta.rs

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -27,5 +27,8 @@ jobs:
       - name: rustfmt check
         run: cargo fmt --all --check
 
+
       - name: test
         run: cargo test
+        env:
+          CI: true # https://insta.rs/docs/quickstart/#continuous-integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "axum-github-webhook-extract",
  "catppuccin",
  "envy",
+ "insta",
  "octocrab",
  "reqwest",
  "serde",
@@ -241,6 +242,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +283,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -694,6 +713,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +791,12 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1375,6 +1413,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
+# insta recommends to do this so that it's more "fun" to use, among other things
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
@@ -45,3 +50,6 @@ installers = []
 targets = ["x86_64-unknown-linux-gnu"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[dev-dependencies]
+insta = { version = "1.40.0", features = ["yaml"] }

--- a/snapshots/issue_comment/created.snap
+++ b/snapshots/issue_comment/created.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#A6E3A1"
+  description_length: 7
+  title_length: 75
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 10937249
+    description: Testing
+    title: "[catppuccin/java] New comment on issue #20: Reconsider OSSRH Authentication"
+    url: "https://github.com/catppuccin/java/issues/20#issuecomment-2351090061"

--- a/snapshots/issue_comment/created_on_pull_request.snap
+++ b/snapshots/issue_comment/created_on_pull_request.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 7
+  colour_hex: "#89B4FA"
+  description_length: 38
+  title_length: 82
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/97406176?v=4"
+      name: trinkey
+      url: "https://github.com/trinkey"
+    color: 9024762
+    description: "404 page isn't styled ughhhhhhhhhhhhhh"
+    title: "[catppuccin/userstyles] New comment on pull request #1323: feat(fontawesome): init"
+    url: "https://github.com/catppuccin/userstyles/pull/1323#issuecomment-2357211297"

--- a/snapshots/issues/closed.snap
+++ b/snapshots/issues/closed.snap
@@ -1,0 +1,18 @@
+---
+source: src/main.rs
+assertion_line: 757
+info:
+  author_name_length: 8
+  colour_hex: "#FAB387"
+  description_length: 0
+  title_length: 67
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 16429959
+    description: ~
+    title: "[catppuccin-rfc/polybar] Issue closed: #13 rockdove-20240921_170510"
+    url: "https://github.com/catppuccin-rfc/polybar/issues/13"

--- a/snapshots/issues/opened.snap
+++ b/snapshots/issues/opened.snap
@@ -1,0 +1,18 @@
+---
+source: src/main.rs
+assertion_line: 741
+info:
+  author_name_length: 8
+  colour_hex: "#A6E3A1"
+  description_length: 8
+  title_length: 67
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 10937249
+    description: rockdove
+    title: "[catppuccin-rfc/polybar] Issue opened: #13 rockdove-20240921_170510"
+    url: "https://github.com/catppuccin-rfc/polybar/issues/13"

--- a/snapshots/issues/reopened.snap
+++ b/snapshots/issues/reopened.snap
@@ -1,0 +1,18 @@
+---
+source: src/main.rs
+assertion_line: 773
+info:
+  author_name_length: 8
+  colour_hex: "#A6E3A1"
+  description_length: 0
+  title_length: 69
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 10937249
+    description: ~
+    title: "[catppuccin-rfc/polybar] Issue reopened: #13 rockdove-20240921_170510"
+    url: "https://github.com/catppuccin-rfc/polybar/issues/13"

--- a/snapshots/membership/added.snap
+++ b/snapshots/membership/added.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#1E1E2E"
+  description_length: 0
+  title_length: 48
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 1973806
+    description: ~
+    title: "[catppuccin-rfc] backwardspy added to staff team"
+    url: "https://github.com/orgs/catppuccin-rfc/teams/staff"

--- a/snapshots/membership/removed.snap
+++ b/snapshots/membership/removed.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#1E1E2E"
+  description_length: 0
+  title_length: 52
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 1973806
+    description: ~
+    title: "[catppuccin-rfc] backwardspy removed from staff team"
+    url: "https://github.com/orgs/catppuccin-rfc/teams/staff"

--- a/snapshots/pull_request/closed.snap
+++ b/snapshots/pull_request/closed.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#FAB387"
+  description_length: 0
+  title_length: 74
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 16429959
+    description: ~
+    title: "[catppuccin-rfc/polybar] Pull request closed: #14 rockdove-20240921_181702"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/14"

--- a/snapshots/pull_request/opened.snap
+++ b/snapshots/pull_request/opened.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#A6E3A1"
+  description_length: 8
+  title_length: 74
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 10937249
+    description: rockdove
+    title: "[catppuccin-rfc/polybar] Pull request opened: #14 rockdove-20240921_181702"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/14"

--- a/snapshots/pull_request/opened_by_bot.snap
+++ b/snapshots/pull_request/opened_by_bot.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 13
+  colour_hex: "#A6E3A1"
+  description_length: 640
+  title_length: 74
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/in/2740?v=4"
+      name: "renovate[bot]"
+      url: "https://github.com/apps/renovate"
+    color: 10937249
+    description: "Welcome to [Renovate](https://redirect.github.com/renovatebot/renovate)! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.\n\n🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.\n\n\n\n---\n### Detected Package Files\n\n * `Dockerfile` (dockerfile)\n * `.github/workflows/dockerfile.yml` (github-actions)\n * `.github/workflows/release.yaml` (github-actions)\n * `go.mod` (gomod)\n\n### Configuration Summary\n\nBased on the default config's presets, Renovate will:\n\n  - Start dependency updates only once this onboarding PR is merged..."
+    title: "[catppuccin-rfc/cli-old] Pull request opened: #1 chore: Configure Renovate"
+    url: "https://github.com/catppuccin-rfc/cli-old/pull/1"

--- a/snapshots/pull_request/reopened.snap
+++ b/snapshots/pull_request/reopened.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#89B4FA"
+  description_length: 0
+  title_length: 76
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 9024762
+    description: ~
+    title: "[catppuccin-rfc/polybar] Pull request reopened: #14 rockdove-20240921_181702"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/14"

--- a/snapshots/pull_request_review/approved.snap
+++ b/snapshots/pull_request_review/approved.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#89B4FA"
+  description_length: 0
+  title_length: 76
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 9024762
+    description: ~
+    title: "[catppuccin-rfc/polybar] Pull request approved: #3 chore: Configure Renovate"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/3#pullrequestreview-2311132096"

--- a/snapshots/pull_request_review/changes_requested.snap
+++ b/snapshots/pull_request_review/changes_requested.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#89B4FA"
+  description_length: 4
+  title_length: 85
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 9024762
+    description: test
+    title: "[catppuccin-rfc/polybar] Pull request changes requested: #3 chore: Configure Renovate"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/3#pullrequestreview-2311206830"

--- a/snapshots/pull_request_review/commented.snap
+++ b/snapshots/pull_request_review/commented.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#89B4FA"
+  description_length: 15
+  title_length: 76
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 9024762
+    description: a normal review
+    title: "[catppuccin-rfc/polybar] Pull request reviewed: #3 chore: Configure Renovate"
+    url: "https://github.com/catppuccin-rfc/polybar/pull/3#pullrequestreview-2319885438"

--- a/snapshots/repository/created.snap
+++ b/snapshots/repository/created.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#F9E2AF"
+  description_length: 0
+  title_length: 53
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 16376495
+    description: ~
+    title: "[catppuccin-rfc/to-be-transferred] Repository created"
+    url: "https://github.com/catppuccin-rfc/to-be-transferred"

--- a/snapshots/repository/renamed.snap
+++ b/snapshots/repository/renamed.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#F9E2AF"
+  description_length: 0
+  title_length: 71
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 16376495
+    description: ~
+    title: "[catppuccin-rfc/renamed-1] Repository renamed from renamed to renamed-1"
+    url: "https://github.com/catppuccin-rfc/renamed-1"

--- a/snapshots/repository/transferred.snap
+++ b/snapshots/repository/transferred.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+info:
+  author_name_length: 8
+  colour_hex: "#F5C2E7"
+  description_length: 0
+  title_length: 89
+---
+embeds:
+  - author:
+      icon_url: "https://avatars.githubusercontent.com/u/58985301?v=4"
+      name: sgoudham
+      url: "https://github.com/sgoudham"
+    color: 16106215
+    description: ~
+    title: "[catppuccin-rfc/to-be-transferred] Repository transferred from sgoudham to catppuccin-rfc"
+    url: "https://github.com/catppuccin-rfc/to-be-transferred"


### PR DESCRIPTION

This moves our unit tests all to snapshot tests using insta.rs which should make
it much nicer to review changes to the fixtures.

We can technically refactor the tests more since a lot of it is duplicated and
can be parameterised / macro'd but I didn't want to spend more time on this.

I'll raise a PR in a minute adjusting the colours as discussed on discord.
